### PR TITLE
Add link existence test for index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "odin-recipes",
+  "version": "1.0.0",
+  "description": "Demonstrating HTML",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/link.test.js
+++ b/tests/link.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('all links in index.html point to existing files', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const html = fs.readFileSync(path.join(repoRoot, 'index.html'), 'utf8');
+  const anchorRegex = /<a\s[^>]*href="([^"]+)"/g;
+  let match;
+  const links = [];
+  while ((match = anchorRegex.exec(html)) !== null) {
+    const href = match[1];
+    if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#')) {
+      continue;
+    }
+    links.push(href);
+  }
+  assert.ok(links.length > 0, 'No links found in index.html');
+  for (const link of links) {
+    const filePath = path.join(repoRoot, link);
+    assert.ok(fs.existsSync(filePath), `Linked file not found: ${link}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add Node test to verify index.html links reference existing recipe files
- configure npm test script to run Node's test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a773594e3c832898284b50d9ca4b9f